### PR TITLE
Fixing porting to Python 3.11

### DIFF
--- a/Pyxis/Internals.py
+++ b/Pyxis/Internals.py
@@ -417,9 +417,9 @@ def interpolate (arg,frame,depth=1,ignore=set(),skip=set(),convert_lists=False):
 # RE pattern matching the [PREFIX<][NAMESPACES.]NAME[?DEFAULT][:BASE|DIR|FILE|BASEPATH][>SUFFIX] syntax
 _substpattern = \
   "(?i)((?P<prefix>[^{}]+)<)?(?P<name>[._a-z][._a-z0-9]*)(\\?(?P<defval>[^}\\$]*?))?(:(?P<command>BASE|DIR|FILE|BASEPATH))?(>(?P<suffix>[^{}]+))?"
-    
+
 class SmartTemplate (string.Template):
-  pattern = "(?P<escaped>\\$\\$)|(\\$(?P<named>[_a-z][_a-z0-9]*))|(\\${(?P<braced>%s)})|(?P<invalid>\\$)"%_substpattern;
+  pattern = "(?P<escaped>\\$\\$)|(\\$(?P<named>[_a-z][_a-z0-9]*))|(\\${{(?P<braced>%s)}})|(?P<invalid>\\$)".format(_substpattern);
 
 class DictProxy (object):
   itempattern = re.compile(_substpattern+"$");

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ installation
  $ python setup.py install
 ```
 
+For newer Python installs (i.e. 3.10 and beyond) this invocation of `setup.py` is deprecated. You can use this instead (in the same directory that `setup.py` is located in):
+
+```shell
+ $ python -m pip install .
+```
+
+If you want to install in a non-default location, you can specify that using a prefix, i.e.:
+
+```shell
+ $ python -m pip install --prefix /install/somewhere/else .
+```
+
 Documentation
 -------------
 


### PR DESCRIPTION
Adding a fix in required for going to a newer version of Python (i.e. 3.10/3.11).